### PR TITLE
Handle 202 authorization redirect

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,8 @@ PUSH_API_KEY = os.getenv('PUSH_API_KEY', '')
 # each user record stores first name, last name, password
 # and coin balances for gold and sweep coins
 users = {}
+# store purchases waiting on auth intent completion
+pending_intents = {}
 
 @app.route('/')
 def home():
@@ -156,8 +158,54 @@ def purchase():
             'gold_coins': user['gold_coins'],
             'sweep_coins': user['sweep_coins'],
         })
+    elif res.status_code == 202:
+        intent_id = resp_data.get('intent_id')
+        if intent_id:
+            pending_intents[intent_id] = {
+                'user': user_email,
+                'sweeps': int(sweeps or 0),
+                'gold': int(gold or 0),
+            }
+        return jsonify({'url': resp_data.get('url'), 'intent_id': intent_id}), 202
     else:
         return jsonify({'status': 'declined'}), 401
+
+
+@app.route('/intent/<intent_id>')
+def intent_status(intent_id):
+    """Check status of an authorization intent and update balance if approved."""
+    info = pending_intents.get(intent_id)
+    if not info:
+        return jsonify({'error': 'unknown intent'}), 404
+    try:
+        res = requests.get(
+            f"{PUSH_SERVICE_URL}/intent/{intent_id}",
+            headers={"Authorization": f"Bearer {PUSH_API_KEY}"},
+            timeout=5,
+        )
+        res.raise_for_status()
+        data = res.json()
+    except requests.RequestException:
+        return jsonify({'error': 'failed to fetch intent status'}), 502
+
+    status = data.get('status')
+    user = users.get(info['user'])
+    if status == 'approved' and user:
+        user['sweep_coins'] += info['sweeps']
+        user['gold_coins'] += info['gold']
+        pending_intents.pop(intent_id, None)
+        return jsonify({
+            'status': 'approved',
+            'gold_coins': user['gold_coins'],
+            'sweep_coins': user['sweep_coins'],
+        })
+
+    if status in ['declined', 'canceled']:
+        pending_intents.pop(intent_id, None)
+        return jsonify({'status': 'declined'})
+
+    # pending
+    return jsonify({'status': 'pending'})
 
 if __name__ == '__main__':
     app.run(debug=True, port=8081)

--- a/templates/home.html
+++ b/templates/home.html
@@ -80,6 +80,17 @@
     #payment-container {
       height: 212px;
     }
+    .auth-content {
+      background: white;
+      border-radius: 4px;
+      width: 360px;
+      height: 700px;
+    }
+    .auth-frame {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
     table { width: 100%; border-collapse: collapse; }
     th, td { padding: 0.5rem; border-bottom: 1px solid #ccc; text-align: center; }
     .header { background: #333; color: white; padding: 1rem; text-align: center; }
@@ -159,6 +170,12 @@
     </div>
   </div>
 
+  <div id="auth-modal" class="modal">
+    <div class="auth-content">
+      <iframe id="auth-frame" class="auth-frame"></iframe>
+    </div>
+  </div>
+
   <div id="signup-modal" class="modal">
     <div class="modal-content">
       <h3>Create Profile</h3>
@@ -208,6 +225,8 @@
     const purchaseResult = document.getElementById('purchase-result');
     const balanceDiv = document.querySelector('.balance');
     const rows = document.querySelectorAll('#package-table .package-row');
+    const authModal = document.getElementById('auth-modal');
+    const authFrame = document.getElementById('auth-frame');
     let widget;
 
     function closeModal() {
@@ -279,10 +298,14 @@
               if (balanceDiv) {
                 balanceDiv.textContent = `${data.gold_coins} Gold | ${data.sweep_coins} Sweeps`;
               }
+              purchaseResult.style.display = 'block';
+            } else if (res.status === 202) {
+              authFrame.src = data.url;
+              authModal.style.display = 'flex';
             } else {
               purchaseResult.textContent = 'Payment declined';
+              purchaseResult.style.display = 'block';
             }
-            purchaseResult.style.display = 'block';
           } catch (e) {
             purchaseResult.textContent = 'Payment request failed';
             purchaseResult.style.display = 'block';
@@ -294,6 +317,29 @@
         });
     };
 
+    window.addEventListener('message', async (e) => {
+      if (authModal.style.display !== 'flex') return;
+      const intentId = e.data && e.data.intent_id;
+      if (!intentId) return;
+      authModal.style.display = 'none';
+      try {
+        const res = await fetch(`/intent/${intentId}`);
+        const data = await res.json();
+        if (res.ok && data.status === 'approved') {
+          purchaseResult.textContent = 'Approved!';
+          if (balanceDiv) {
+            balanceDiv.textContent = `${data.gold_coins} Gold | ${data.sweep_coins} Sweeps`;
+          }
+        } else {
+          purchaseResult.textContent = 'Payment declined';
+        }
+        purchaseResult.style.display = 'block';
+      } catch (err) {
+        purchaseResult.textContent = 'Payment verification failed';
+        purchaseResult.style.display = 'block';
+      }
+    });
+
     const signupBtn = document.getElementById('signup-btn');
     const signupModal = document.getElementById('signup-modal');
     const signupClose = document.getElementById('close-signup-modal');
@@ -303,6 +349,7 @@
     window.onclick = (e) => {
       if (e.target === purchaseModal) closeModal();
       if (e.target === signupModal) signupModal.style.display = 'none';
+      if (e.target === authModal) authModal.style.display = 'none';
     };
   </script>
 </body>


### PR DESCRIPTION
## Summary
- support 202 responses from the `/authorize` endpoint
- display auth iframe modal and finalize purchase on postMessage

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6845e76e4418832ab783fb9839ced44b