### PR TITLE
Fix crash when session user missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,9 @@ pending_intents = {}
 @app.route('/')
 def home():
     user = session.get('user')
+    if user and user not in users:
+        session.pop('user', None)
+        user = None
     return render_template('home.html', user=user, users=users)
 
 @app.route('/signup', methods=['GET', 'POST'])


### PR DESCRIPTION
## Summary
- clear invalid session user when restarting server and rendering homepage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859a376946c832ab4e558211b4cec1e